### PR TITLE
build.rs: support clang

### DIFF
--- a/libssh-rs-sys/build.rs
+++ b/libssh-rs-sys/build.rs
@@ -101,7 +101,7 @@ fn main() {
     }
 
     let compiler = cfg.get_compiler();
-    if compiler.is_like_gnu() {
+    if compiler.is_like_gnu() || compiler.is_like_clang() {
         cfg.define("HAVE_COMPILER__FUNCTION__", Some("1"));
         cfg.define("HAVE_COMPILER__FUNC__", Some("1"));
         cfg.define("HAVE_GCC_THREAD_LOCAL_STORAGE", Some("1"));


### PR DESCRIPTION
Ran into an error complaining that my compiler didn't provide __func__ trying to build on wsl2 with ubuntu with CC set to clang.

__func__ and __FUNCTION__ are definitely supported. The thread local storage wikipedia says __thread is supported but I admit I didn't test it.