### PR TITLE
Remove Channel Callbacks while Dropping 

### DIFF
--- a/libssh-rs/src/channel.rs
+++ b/libssh-rs/src/channel.rs
@@ -44,6 +44,7 @@ impl Drop for Channel {
     fn drop(&mut self) {
         let (_sess, chan) = self.lock_session();
         unsafe {
+            sys::ssh_remove_channel_callbacks(chan, self._callbacks.as_ref() as *const _ as *mut _);
             sys::ssh_channel_free(chan);
         }
     }

--- a/libssh-rs/src/channel.rs
+++ b/libssh-rs/src/channel.rs
@@ -42,9 +42,12 @@ unsafe impl Send for Channel {}
 
 impl Drop for Channel {
     fn drop(&mut self) {
+        unsafe {
+            // Prevent any callbacks firing as part the remainder of this drop operation
+            sys::ssh_remove_channel_callbacks(self.chan_inner, self._callbacks.as_mut());
+        }
         let (_sess, chan) = self.lock_session();
         unsafe {
-            sys::ssh_remove_channel_callbacks(chan, self._callbacks.as_ref() as *const _ as *mut _);
             sys::ssh_channel_free(chan);
         }
     }


### PR DESCRIPTION
Hi! Thanks for this great library. During development on Windows, I noticed a random crash happening in libssh C source `channels.c`. 

```c
    /*
    * The remote eof doesn't break things if there was still data into read
    * buffer because the eof is ignored until the buffer is empty.
    */
    channel->remote_eof = 1;

    ssh_callbacks_execute_list(channel->callbacks,               // <-------------- Bad access
                               ssh_channel_callbacks,
                               channel_close_function,
                               channel->session,
                               channel);

```

After tried to use latest official source and made a few changes, I found removing channel callbacks before freeing channel seemingly solved this issue.