### PR TITLE
Add OpenFlags for SFTP file open options

### DIFF
--- a/libssh-rs/Cargo.toml
+++ b/libssh-rs/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 bitflags = "1.3"
+libc = "0.2"
 libssh-rs-sys = { version = "0.2.2", path = "../libssh-rs-sys" }
 thiserror = "1.0"
 openssl-sys = "0.9.93"


### PR DESCRIPTION
Closes #20

I chose to use bitflags since I didn't really feel strongly between the suggested options and bitflags are simpler to write.

I added the libc crate to provide the bitflag values.

I renamed the flags to be more descriptive, and added an alias for creating a new file since it felt fitting for a high level interface.

I did not add every possible flag from `open(2)`, since I'm fairly certain this subset of flags are the only meaningful ones.