### PR TITLE
Defined __ANDROID_API__ to fix build on Android

### DIFF
--- a/libssh-rs-sys/build.rs
+++ b/libssh-rs-sys/build.rs
@@ -106,6 +106,9 @@ fn main() {
         cfg.define("HAVE_NTOHLL", Some("1"));
         cfg.define("HAVE_HTONLL", Some("1"));
     }
+    if target.contains("android") {
+        cfg.define("__ANDROID_API__", Some("21"));
+    }
 
     let compiler = cfg.get_compiler();
     if compiler.is_like_gnu() || compiler.is_like_clang() {


### PR DESCRIPTION
In libssh, `strerror_r` was assumed to return `char*` when glibc is used, and assume it returns `int` instead. On Android this was true until after API 23, it switched to use GNU flavor, causing the library failed to build.

This PR specifies 21 as Android API target, fixes the build issue.