### PR TITLE
Fixed Android Build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,70 @@
+name: Android
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: build (android-${{ matrix.android-api }} on ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        android-api: [ 21, 28 ]
+        include:
+          - os: windows-latest
+            clang-suffix: .cmd
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Install Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: 'r26d'
+      - name: Adding NDK to PATH (*nix)
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        run: echo ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/*/bin >> $GITHUB_PATH
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+      - name: Adding NDK to PATH (Windows)
+        shell: pwsh
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: echo "${env:ANDROID_NDK_HOME}\toolchains\llvm\prebuilt\windows-x86_64\bin" >> $env:GITHUB_PATH
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+      - name: Download prebuilt OpenSSL
+        uses: actions/checkout@v4
+        with:
+          repository: KDAB/android_openssl
+          path: android_openssl
+      - name: Build and test
+        run: |
+          rustc -V
+          cargo -V
+          cargo build --target aarch64-linux-android
+          cargo build --target armv7-linux-androideabi
+          cargo build --target i686-linux-android
+          cargo build --target x86_64-linux-android
+        env:
+          OPENSSL_INCLUDE_DIR: "${{ github.workspace }}/android_openssl/ssl_1.1/include"
+          AARCH64_LINUX_ANDROID_OPENSSL_LIB_DIR: "${{ github.workspace }}/android_openssl/ssl_1.1/arm64-v8a"
+          ARMV7_LINUX_ANDROIDEABI_OPENSSL_LIB_DIR: "${{ github.workspace }}/android_openssl/ssl_1.1/armeabi-v7a"
+          I686_LINUX_ANDROID_OPENSSL_LIB_DIR: "${{ github.workspace }}/android_openssl/ssl_1.1/x86"
+          X86_64_LINUX_ANDROID_OPENSSL_LIB_DIR: "${{ github.workspace }}/android_openssl/ssl_1.1/x86_64"
+          CC_aarch64_linux_android: "aarch64-linux-android${{ matrix.android-api }}-clang${{ matrix.clang-suffix }}"
+          CC_armv7-linux-androideabi: "armv7a-linux-androideabi${{ matrix.android-api }}-clang${{ matrix.clang-suffix }}"
+          CC_i686_linux_android: "i686-linux-android${{ matrix.android-api }}-clang${{ matrix.clang-suffix }}"
+          CC_x86_64_linux_android: "x86_64-linux-android${{ matrix.android-api }}-clang${{ matrix.clang-suffix }}"

--- a/libssh-rs-sys/build.rs
+++ b/libssh-rs-sys/build.rs
@@ -262,6 +262,8 @@ fn main() {
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=shell32");
         println!("cargo:rustc-link-lib=ntdll");
+        println!("cargo:rustc-link-lib=iphlpapi");
+        println!("cargo:rustc-link-lib=ws2_32");
     } else {
         println!("cargo:rustc-link-lib=ssl");
         println!("cargo:rustc-link-lib=crypto");

--- a/libssh-rs-sys/build.rs
+++ b/libssh-rs-sys/build.rs
@@ -14,7 +14,6 @@ fn main() {
 
     let mut cfg = cc::Build::new();
     cfg.define("LIBSSH_STATIC", None);
-    cfg.define("_GNU_SOURCE", None);
     cfg.include("vendored/include");
     cfg.flag_if_supported("-Wno-deprecated-declarations");
 
@@ -29,6 +28,7 @@ fn main() {
     let openssl_version = u64::from_str_radix(&openssl_version, 16).unwrap();
 
     let target = std::env::var("TARGET").unwrap();
+
     let target_family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
     cfg.define("GLOBAL_CLIENT_CONFIG", Some("\"/etc/ssh/ssh_config\""));
     cfg.define(
@@ -106,8 +106,11 @@ fn main() {
         cfg.define("HAVE_NTOHLL", Some("1"));
         cfg.define("HAVE_HTONLL", Some("1"));
     }
+
     if target.contains("android") {
-        cfg.define("__ANDROID_API__", Some("21"));
+        cfg.define("_BSD_SOURCE", None);
+    } else {
+        cfg.define("_GNU_SOURCE", None);
     }
 
     let compiler = cfg.get_compiler();


### PR DESCRIPTION
Hi! Sorry for the previous PR #23 , as it only partially solves build issue for Android, and is inconsistent across hosts.

This PR instead of defining `__ANDROID_API__`, defines `_BSD_SOURCE` only for Android to ensure build consistency across different versions. Also, workflow for Android has been added to verify the whole build process on Linux, Windows and macOS.

[The same patch](https://gitlab.com/mariotaku/libssh-mirror/-/compare/master...fix%2Fandroid-stderr_r?from_project_id=6055600) has been verified working for upstream CMake project as well, so I believe this is the correct patch to get a working build without worrying about target API version.